### PR TITLE
Add copying of ComponentDesc to avoid pointer invalidation

### DIFF
--- a/Engine/Editor/private/LevelEditor/LevelEditor.cpp
+++ b/Engine/Editor/private/LevelEditor/LevelEditor.cpp
@@ -42,7 +42,7 @@ namespace GameEngine
 				{
 					assert(World::WorldParser::GetCustomComponents().contains(geometryAttribute->second));
 
-					entity.set(EntitySystem::LevelEditorECS::PositionDesc{ &positionAttribute->second });
+					entity.set(EntitySystem::LevelEditorECS::PositionDesc { new World::LevelObject::ComponentDesc(positionAttribute->second) });
 
 					// Can be set to 0 since it doesn't matter now, will be updated by the system
 					entity.set(EntitySystem::EditorECS::Position{ 0.0f, 0.0f, 0.0f });


### PR DESCRIPTION
positionAttribute is a componentList (std::vector) iterator. In the edited line a pointer to positionAttribute->second was set to PositionDesc. However, this pointer (as a pointer to componentList element) may invalidate later.

Copying ComponentDesc (std::string) would solve the problem. The other option is to use std::deque. 